### PR TITLE
feat: add post_steps to assertion

### DIFF
--- a/src/asserters/base.ts
+++ b/src/asserters/base.ts
@@ -71,6 +71,17 @@ export default abstract class AsserterBase {
       indentLog(8, result)
     }
 
+    if (this.assertion.post_steps) {
+      indentLog(8, 'Running post assertion steps')
+      const steps: string[] = Array.isArray(this.assertion.post_steps) ?
+        this.assertion.post_steps :
+        [this.assertion.post_steps]
+      for (const step of steps) {
+        indentLog(10, step)
+        await exec(step, {cwd: this.workingDir})
+      }
+    }
+
     // 3.
     const {stdout} = await exec(`git -C ${this.workingDir} status`)
     if (stdout.toString().match(/nothing to commit, working tree clean/)) {
@@ -87,7 +98,7 @@ export default abstract class AsserterBase {
     await exec(`git -C ${this.workingDir} checkout ${masterMain}`)
   }
 
-  protected abstract async uniqWork(): Promise<string | void>;
+  protected abstract uniqWork(): Promise<string | void>;
 
   private get commitDescription() {
     return this.assertion.description || `leif ${this.assertion.type} assertion`


### PR DESCRIPTION
Adds a `post_steps` field so that we can run arbitrary bash code after an assertion has been made but before the changes have been committed. For example:

```yaml
      - type: json-has-properties
        description: 'chore: sync package.json [skip-validate-pr]'
        target_relative_filepath: './package.json'
        source_relative_filepath: cron/package/package.json
        post_steps: |
          if [ ! -f command-snapshot.json ]; then
            bin/run snapshot:generate
          fi
```

The steps can be formatted in any of the following ways:
```yaml
post_steps: echo "Hello World"
```

```yaml
post_steps:
  - echo "Hello"
  - echo "World"
```

```yaml
post_steps: |
  echo "Hello"
  echo "World"
  ls
```