### PR TITLE
feat: add node-lerna-project-has-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@oclif/config": "^1.13.3",
     "@octokit/rest": "^16.34.1",
     "cli-ux": "^5.3.3",
+    "fast-glob": "^3.2.5",
     "fs-extra": "^9.1.0",
     "js-yaml": "^3.14.1"
   },

--- a/src/asserters/index.ts
+++ b/src/asserters/index.ts
@@ -2,13 +2,18 @@ import {FileExactMatchAsserter, FileDoesNotExistAsserter} from './file'
 import {GithubRepoPropertyValueAsserter} from './github'
 import {JsonHasPropertiesAsserter} from './json'
 import {YamlHasPropertiesAsserter} from './yaml'
-import {NodeProjectHasDepsAsserter, NodeProjectDoesNotHaveDepsAsserter} from './node'
+import {
+  NodeProjectHasDepsAsserter,
+  NodeProjectDoesNotHaveDepsAsserter,
+  NodeLernaProjectHasDepsAsserter,
+} from './node'
 
 export const AsserterLookup: { [key: string]: any } = {
   'file-is-exact': FileExactMatchAsserter,
   'file-does-not-exist': FileDoesNotExistAsserter,
   'json-has-properties': JsonHasPropertiesAsserter,
   'node-project-has-deps': NodeProjectHasDepsAsserter,
+  'node-lerna-project-has-deps': NodeLernaProjectHasDepsAsserter,
   'node-project-does-not-have-deps': NodeProjectDoesNotHaveDepsAsserter,
   'github-repo-property-has-value': GithubRepoPropertyValueAsserter,
   'yaml-has-properties': YamlHasPropertiesAsserter,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,18 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
Adds `node-lerna-project-has-deps` asserter

Usage:
```yaml
  sync-lerna-plugin-package-json:
    description: 'chore: sync package.json'
    assertions:
      - type: node-lerna-project-has-deps
        description: 'chore: sync dependencies [skip-validate-pr]'
        if: test -f ./lerna.json
        manager: yarn
        target_glob_filepath: 'packages/plugin-*'
        dev_dependencies:
          - '@oclif/plugin-command-snapshot@^2.0.0'
          - '@salesforce/plugin-command-reference@^1.3.0'
```