### PR TITLE
feat: add target_glob_filepath to json asserter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@oclif/config": "^1.13.3",
     "@octokit/rest": "^16.34.1",
     "cli-ux": "^5.3.3",
+    "fast-glob": "^3.2.5",
     "fs-extra": "^9.1.0",
     "js-yaml": "^3.14.1"
   },

--- a/src/asserters/json.ts
+++ b/src/asserters/json.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
+import * as glob from 'fast-glob'
 
 import AsserterBase from './base'
 import {deepAssign} from '../utils'
@@ -7,9 +8,19 @@ import {deepAssign} from '../utils'
 export class JsonHasPropertiesAsserter extends AsserterBase {
   protected async uniqWork() {
     const sourceJSON = require(path.join(this.templateDir, this.assertion.source_relative_filepath))
-    const targetJSONPath = path.join(this.workingDir, this.assertion.target_relative_filepath)
-    const targetJSON = require(targetJSONPath)
-    const assertedJSON = deepAssign({...targetJSON}, sourceJSON)
-    await fs.writeFile(targetJSONPath, JSON.stringify(assertedJSON, null, 2) + '\n')
+    const jsonPaths: string[] = []
+    if (this.assertion.target_relative_filepath) {
+      jsonPaths.push(path.join(this.workingDir, this.assertion.target_relative_filepath))
+    } else if (this.assertion.target_glob_filepath) {
+      const matches = await glob(path.join(this.workingDir, this.assertion.target_glob_filepath))
+      jsonPaths.push(...matches)
+    } else {
+      throw new Error('Neither target_glob_filepath nor target_relative_filepath are provided')
+    }
+    for (const targetJSONPath of jsonPaths) {
+      const targetJSON = require(targetJSONPath)
+      const assertedJSON = deepAssign({...targetJSON}, sourceJSON)
+      await fs.writeFile(targetJSONPath, JSON.stringify(assertedJSON, null, 2) + '\n')
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,18 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
Adds `target_glob_filepath` field to `json-has-properties` so that you can assert on multiple json files

Usage:
```yaml
  sync-lerna-plugin-package-json:
    description: 'chore: sync package.json'
    assertions:
      - type: json-has-properties
        description: 'chore: sync package.json [skip-validate-pr]'
        if: test -f ./lerna.json
        target_glob_filepath: 'packages/plugin-*/package.json'
        source_relative_filepath: cron/plugins/package.json
        post_steps: |
          PACKAGES=$(ls -1 -d "$PWD/packages/"* | grep plugin-)
          for PACKAGE in $PACKAGES
          do
            if [ ! -f command-snapshot.json ]; then
              $PACKAGE/bin/run snapshot:generate
            fi
          done
```