### PR TITLE
feat: add readme-has-badges asserter

### DIFF
--- a/src/asserters/badge.ts
+++ b/src/asserters/badge.ts
@@ -1,0 +1,41 @@
+import * as path from 'path'
+import * as fs from 'fs-extra'
+
+import AsserterBase from './base'
+
+const LICENSES: Record<string, string> = {
+  'BSD-2-Clause': 'https://img.shields.io/badge/License-BSD%202--Clause-brightgreen.svg',
+  'BSD 2-Clause': 'https://img.shields.io/badge/License-BSD%202--Clause-brightgreen.svg',
+  'BSD-3-Clause': 'https://img.shields.io/badge/License-BSD%203--Clause-brightgreen.svg',
+  'BSD 3-Clause': 'https://img.shields.io/badge/License-BSD%203--Clause-brightgreen.svg',
+  MIT: 'https://img.shields.io/badge/License-MIT-brightgreen.svg',
+}
+
+export class ReadmeHasBadgesAsserter extends AsserterBase {
+  protected async uniqWork() {
+    const pkgJson = require(path.join(this.workingDir, 'package.json'))
+
+    const {name, license} = pkgJson
+    const BADGES: Record<string, string> = {
+      npm: `[![NPM](https://img.shields.io/npm/v/${name}.svg?label=${name})](https://www.npmjs.com/package/${name})`,
+      circleci: `[![CircleCI](https://circleci.com/gh/${this.repoFullName}/tree/${this.mainBranchName}.svg?style=shield)](https://circleci.com/gh/${this.repoFullName}/tree/${this.mainBranchName})`,
+      license: `[![License](${LICENSES[license]})](https://raw.githubusercontent.com/${this.repoFullName}/${this.mainBranchName}/LICENSE.txt)`,
+      downloads: `[![Downloads/week](https://img.shields.io/npm/dw/${name}.svg)](https://npmjs.org/package/${name})`,
+    }
+    const requestedBadges = (this.assertion.badges || []) as string[]
+    const badges: string[] = requestedBadges.map(badge => BADGES[badge])
+
+    const readmePath = path.join(this.workingDir, 'README.md')
+    let readme = fs.readFileSync(readmePath, 'utf-8')
+    const headerRegex = /^#\s(.*?)\n|(=*)\n/gi
+    const header = readme.match(headerRegex)
+    if (header) {
+      // if we can find a header, insert the badges just below that
+      readme = readme.replace(header[0], `${header[0]}\n${badges.join(' ')}\n`)
+    } else {
+      // if we can't find the header, insert the badges as the first line
+      readme = `${badges.join(' ')}\n${readme}`
+    }
+    fs.writeFileSync(readmePath, readme)
+  }
+}

--- a/src/asserters/base.ts
+++ b/src/asserters/base.ts
@@ -19,12 +19,15 @@ export default abstract class AsserterBase {
 
   protected repoFullName: string
 
+  protected mainBranchName: string
+
   constructor({assertion, repoFullName, dryRun, branchName, templateDir}: AsserterServiceConfig) {
     this.assertion = assertion
     this.branchName = branchName
     this.templateDir = templateDir
     this.dryRun = dryRun
     this.repoFullName = repoFullName
+    this.mainBranchName = masterBranchName(this.workingDir)
   }
 
   protected get workingDir() {
@@ -32,10 +35,8 @@ export default abstract class AsserterBase {
   }
 
   async run() {
-    const masterMain = masterBranchName(this.workingDir)
-
     // 1.
-    await exec(`git -C ${this.workingDir} checkout ${masterMain}`) // branch from master/main
+    await exec(`git -C ${this.workingDir} checkout ${this.mainBranchName}`) // branch from master/main
     try {
       await exec(`git -C ${this.workingDir} checkout ${this.branchName}`)
       indentLog(8, `Checking out branch ${this.branchName}...`)
@@ -61,7 +62,7 @@ export default abstract class AsserterBase {
         indentLog(8, 'Passed `if` guard, continuing assertion...')
       } catch (error) {
         indentLog(8, 'Did not pass `if` guard, skipping assertion...')
-        await exec(`git -C ${this.workingDir} checkout ${masterMain}`)
+        await exec(`git -C ${this.workingDir} checkout ${this.mainBranchName}`)
         return
       }
     }
@@ -95,7 +96,7 @@ export default abstract class AsserterBase {
     }
 
     // work is done, return to master/main
-    await exec(`git -C ${this.workingDir} checkout ${masterMain}`)
+    await exec(`git -C ${this.workingDir} checkout ${this.mainBranchName}`)
   }
 
   protected abstract uniqWork(): Promise<string | void>;

--- a/src/asserters/index.ts
+++ b/src/asserters/index.ts
@@ -1,6 +1,7 @@
 import {FileExactMatchAsserter, FileDoesNotExistAsserter} from './file'
 import {GithubRepoPropertyValueAsserter} from './github'
 import {JsonHasPropertiesAsserter} from './json'
+import {ReadmeHasBadgesAsserter} from './badge'
 import {YamlHasPropertiesAsserter} from './yaml'
 import {
   NodeProjectHasDepsAsserter,
@@ -9,12 +10,13 @@ import {
 } from './node'
 
 export const AsserterLookup: { [key: string]: any } = {
-  'file-is-exact': FileExactMatchAsserter,
   'file-does-not-exist': FileDoesNotExistAsserter,
+  'file-is-exact': FileExactMatchAsserter,
+  'github-repo-property-has-value': GithubRepoPropertyValueAsserter,
   'json-has-properties': JsonHasPropertiesAsserter,
-  'node-project-has-deps': NodeProjectHasDepsAsserter,
   'node-lerna-project-has-deps': NodeLernaProjectHasDepsAsserter,
   'node-project-does-not-have-deps': NodeProjectDoesNotHaveDepsAsserter,
-  'github-repo-property-has-value': GithubRepoPropertyValueAsserter,
+  'node-project-has-deps': NodeProjectHasDepsAsserter,
+  'readme-has-badges': ReadmeHasBadgesAsserter,
   'yaml-has-properties': YamlHasPropertiesAsserter,
 }


### PR DESCRIPTION
adds `readme-has-badges` asserter.

The following badges are supported
- npm
- circleci
- license (MIT, BSD 2, BSD 3)
- downloads

The asserter will try to put the badges directly under the header, but if no header is found it will place the badges at the very top