### PR TITLE
fix: allow leif to run all sequences in a workflow

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -63,7 +63,7 @@ export default class Run extends Command {
         preparedWorkflows = preparedWorkflows.filter(workflow => {
           const shouldInclude = workflows.includes(workflow.id)
           if (shouldInclude) {
-            workflow.sequences = workflow.sequences.filter(sequence => sequences.includes(sequence.id))
+            workflow.sequences = workflow.sequences.filter(sequence => sequences ? sequences.includes(sequence.id) : sequence)
           }
           return shouldInclude
         })


### PR DESCRIPTION
This PR contains a fix for allowing a user to run all sequences under a workflow if just a workflow, `-w`, is specified.