### PR TITLE
feat: add deepAssign array behavior

### DIFF
--- a/src/asserters/json.ts
+++ b/src/asserters/json.ts
@@ -19,7 +19,7 @@ export class JsonHasPropertiesAsserter extends AsserterBase {
     }
     for (const targetJSONPath of jsonPaths) {
       const targetJSON = require(targetJSONPath)
-      const assertedJSON = deepAssign({...targetJSON}, sourceJSON)
+      const assertedJSON = deepAssign({...targetJSON}, sourceJSON, {arrayBehavior: this.assertion.array_behavior})
       await fs.writeFile(targetJSONPath, JSON.stringify(assertedJSON, null, 2) + '\n')
     }
   }

--- a/src/asserters/yaml.ts
+++ b/src/asserters/yaml.ts
@@ -11,7 +11,7 @@ export class YamlHasPropertiesAsserter extends AsserterBase {
     const sourceYamlAsJson = yaml.load(await fs.readFile(path.join(this.templateDir, this.assertion.source_relative_filepath), 'utf-8')) as object
     const targetYamlAsJson = yaml.load(await fs.readFile(targetYamlPath, 'utf-8')) as object
 
-    const assertedJson = deepAssign({...targetYamlAsJson}, sourceYamlAsJson)
+    const assertedJson = deepAssign({...targetYamlAsJson}, sourceYamlAsJson, {arrayBehavior: this.assertion.array_behavior})
     const assertedYaml = yaml.dump(assertedJson, {indent: 2})
     await fs.writeFile(targetYamlPath, assertedYaml)
   }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,218 @@
+const assert = require('assert')
+
+import {deepAssign} from '../src/utils'
+
+describe('deepAssign', function () {
+  let target = {}
+  beforeEach(() => {
+    // deepAssign mutates target
+    // so reassign it
+    target = {
+      greeting: 'Hello',
+      name: 'world',
+      nested: {
+        bool: true,
+        int: 123,
+        string: '!',
+      },
+      arrayUnchanged: [1, 2, 3],
+      array1: [
+        {
+          id: 0,
+          description: 'foo',
+        },
+        {
+          id: 1,
+          description: 'bar',
+        },
+        {
+          id: 2,
+          description: 'baz',
+        },
+      ],
+    }
+  })
+
+  const source = {
+    name: 'leif',
+    nested: {
+      bool: false,
+    },
+    array1: [
+      {
+        id: 3,
+        description: 'qux',
+      },
+    ],
+  }
+
+  it('should replace the array', function () {
+    const expected = {
+      greeting: 'Hello',
+      name: 'leif',
+      nested: {
+        bool: false,
+        int: 123,
+        string: '!',
+      },
+      arrayUnchanged: [1, 2, 3],
+      array1: [
+        {
+          id: 3,
+          description: 'qux',
+        },
+      ],
+    }
+    const actual = deepAssign(target, source)
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should concat the array', function () {
+    const expected = {
+      greeting: 'Hello',
+      name: 'leif',
+      nested: {
+        bool: false,
+        int: 123,
+        string: '!',
+      },
+      arrayUnchanged: [1, 2, 3],
+      array1: [
+        {
+          id: 0,
+          description: 'foo',
+        },
+        {
+          id: 1,
+          description: 'bar',
+        },
+        {
+          id: 2,
+          description: 'baz',
+        },
+        {
+          id: 3,
+          description: 'qux',
+        },
+      ],
+    }
+    const actual = deepAssign(target, source, {arrayBehavior: 'concat'})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should merge the array on indexes', function () {
+    const source = {
+      name: 'leif',
+      nested: {
+        bool: false,
+      },
+      array1: [
+        {},
+        {description: 'qux'},
+        'mixed type',
+        {
+          id: 3,
+          description: 'qux',
+        },
+      ],
+    }
+
+    const expected = {
+      greeting: 'Hello',
+      name: 'leif',
+      nested: {
+        bool: false,
+        int: 123,
+        string: '!',
+      },
+      arrayUnchanged: [1, 2, 3],
+      array1: [
+        {
+          id: 0,
+          description: 'foo',
+        },
+        {
+          id: 1,
+          description: 'qux',
+        },
+        'mixed type',
+        {
+          id: 3,
+          description: 'qux',
+        },
+      ],
+    }
+    const actual = deepAssign(target, source, {arrayBehavior: 'merge'})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('should use unique-object-keys method for handling array', function () {
+    const target = {
+      workflows: [
+        {foo: {
+          id: 0,
+          desc: 'foo',
+        }},
+        {bar: {
+          id: 1,
+          desc: 'bar',
+        }},
+        {baz: {
+          id: 2,
+          desc: 'baz',
+          array: [0, 1, 2],
+        }},
+      ],
+    }
+
+    const source = {
+      workflows: [
+        {
+          baz: {
+            id: 2,
+            desc: 'updated',
+            array: [3, 2, 1],
+          },
+        },
+        {
+          qux: {
+            id: 3,
+            desc: 'qux',
+          },
+        },
+      ],
+    }
+
+    const expected = {
+      workflows: [
+        {
+          foo: {
+            id: 0,
+            desc: 'foo',
+          },
+        },
+        {
+          bar: {
+            id: 1,
+            desc: 'bar',
+          },
+        },
+        {
+          baz: {
+            id: 2,
+            desc: 'updated',
+            array: [3, 2, 1],
+          },
+        },
+        {
+          qux: {
+            id: 3,
+            desc: 'qux',
+          },
+        },
+      ],
+    }
+    const actual = deepAssign(target, source, {arrayBehavior: 'unique-key-objects'})
+    assert.deepStrictEqual(actual, expected)
+  })
+})


### PR DESCRIPTION
This PR adds 4 array handling behaviors to `JsonHasPropertiesAsserter` & `YamlHasPropertiesAsserter`:

1. 'replace' - (default) will wholesale replace the target array with whatever the source value is
2. 'concat' - will concat the source value onto the end of the target
3. 'merge' - will run deepAssign on the source and target values (objects) at every index position
4. 'unique-key-objectss' - for very particular use-cases like CircleCi configs which often have arrays of objects themselves wrapped in an object with 1 unique key, this method will look for a matching unique key value and update that object or concat if not found. It treats other arrays that aren't unique key as a 'merge'. 

This value is set in leif.yml by adding the `array_behavior` property onto the assertion.

See the util.test.ts for examples.

Closes #71 