### PR TITLE
feat: add run-script asserter

### DIFF
--- a/src/asserters/index.ts
+++ b/src/asserters/index.ts
@@ -3,7 +3,7 @@ import {GithubRepoPropertyValueAsserter} from './github'
 import {JsonHasPropertiesAsserter} from './json'
 import {ReadmeHasBadgesAsserter} from './badge'
 import {YamlHasPropertiesAsserter} from './yaml'
-import {RunScriptAsserter} from './script'
+import {RunCommandsAsserter} from './script'
 import {
   NodeProjectHasDepsAsserter,
   NodeProjectDoesNotHaveDepsAsserter,
@@ -20,5 +20,5 @@ export const AsserterLookup: { [key: string]: any } = {
   'node-project-has-deps': NodeProjectHasDepsAsserter,
   'readme-has-badges': ReadmeHasBadgesAsserter,
   'yaml-has-properties': YamlHasPropertiesAsserter,
-  'run-script': RunScriptAsserter,
+  'run-commands': RunCommandsAsserter,
 }

--- a/src/asserters/index.ts
+++ b/src/asserters/index.ts
@@ -3,6 +3,7 @@ import {GithubRepoPropertyValueAsserter} from './github'
 import {JsonHasPropertiesAsserter} from './json'
 import {ReadmeHasBadgesAsserter} from './badge'
 import {YamlHasPropertiesAsserter} from './yaml'
+import {RunScriptAsserter} from './script'
 import {
   NodeProjectHasDepsAsserter,
   NodeProjectDoesNotHaveDepsAsserter,
@@ -19,4 +20,5 @@ export const AsserterLookup: { [key: string]: any } = {
   'node-project-has-deps': NodeProjectHasDepsAsserter,
   'readme-has-badges': ReadmeHasBadgesAsserter,
   'yaml-has-properties': YamlHasPropertiesAsserter,
+  'run-script': RunScriptAsserter,
 }

--- a/src/asserters/script.ts
+++ b/src/asserters/script.ts
@@ -1,0 +1,22 @@
+import * as path from 'path'
+
+import AsserterBase from './base'
+import {exec} from '../utils'
+
+export class RunScriptAsserter extends AsserterBase {
+  protected async uniqWork() {
+    let command = this.assertion.command
+
+    if (this.assertion.args) {
+      command += ` ${this.assertion.args.join(' ')}`
+    }
+
+    command += ` ${path.join(this.templateDir, this.assertion.script_relative_filepath)}`
+
+    try {
+      await exec(command, {cwd: this.workingDir})
+    } catch (err) {
+      throw  err
+    }
+  }
+}

--- a/src/asserters/script.ts
+++ b/src/asserters/script.ts
@@ -4,19 +4,15 @@ import {exec} from '../utils'
 export class RunCommandsAsserter extends AsserterBase {
   protected async uniqWork() {
     if (!this.assertion.commands) {
-      throw new Error(`No commands were provided in the sequence.`)
+      throw new Error('No commands were provided in the sequence.')
     }
 
     const commands: string[] = Array.isArray(this.assertion.commands) ?
       this.assertion.commands :
       [this.assertion.commands]
 
-    for (let cmd of commands) {
-      try {
-        await exec(cmd, {cwd: this.workingDir})
-      } catch(err) {
-        throw err
-      }
+    for (const cmd of commands) {
+      await exec(cmd, {cwd: this.workingDir})
     }
   }
 }

--- a/src/asserters/script.ts
+++ b/src/asserters/script.ts
@@ -1,22 +1,22 @@
-import * as path from 'path'
-
 import AsserterBase from './base'
 import {exec} from '../utils'
 
-export class RunScriptAsserter extends AsserterBase {
+export class RunCommandsAsserter extends AsserterBase {
   protected async uniqWork() {
-    let command = this.assertion.command
-
-    if (this.assertion.args) {
-      command += ` ${this.assertion.args.join(' ')}`
+    if (!this.assertion.commands) {
+      throw new Error(`No commands were provided in the sequence.`)
     }
 
-    command += ` ${path.join(this.templateDir, this.assertion.script_relative_filepath)}`
+    const commands: string[] = Array.isArray(this.assertion.commands) ?
+      this.assertion.commands :
+      [this.assertion.commands]
 
-    try {
-      await exec(command, {cwd: this.workingDir})
-    } catch (err) {
-      throw  err
+    for (let cmd of commands) {
+      try {
+        await exec(cmd, {cwd: this.workingDir})
+      } catch(err) {
+        throw err
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a new `run-script` asserter.

**Use case:**
We want to use `yq` to run queries on all circle config files defined in our leif setup.
Whenever we have a very specific "state" we have to manually update each repo, with this asserter we can pass to leif a script to run on each repo.

Example:
```yaml
  migrate-to-scheduled-pipelines:
    description: 'chore(ci): migrate to scheduled pipelines'
    assertions:
      - type: run-script
        description: 'chore(ci): migrate to scheduled pipelines [skip-validate-pr]'
        command: 'npx zx'
        args:
          - '--quiet'
        script_relative_filepath: scripts/migrate-to-scheduled-pipelines.mjs
        if: test -f ./.circleci/config.yml
        source_relative_filepath: templates/circleci/circle.yml
        post_steps: circleci config validate
```